### PR TITLE
Add assertions to verify assumptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,5 +61,6 @@ task precommit {
 }
 
 run{
+    enableAssertions = true
     standardInput = System.in
 }

--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -74,6 +74,7 @@ public class Duke extends Application {
         } else {
             images = loadImagesFromFile("DaUser.png", "DaDuke.png", getParameters().getRaw().get(0));
         }
+        assert (images != null && images.length >= 2) : "Images should be loaded.";
         // Container for chat message boxes to provide scroll functionality.
         ScrollPane scrollPane = new ScrollPane();
         // Contains main chat message content vertically
@@ -107,6 +108,8 @@ public class Duke extends Application {
 
 
         // set up the Duke chat bot agent.
+        assert images[0] != null : "User avatar image should exist";
+        assert images[1] != null : "Agent avatar image should exist";
         Duke guiDuke = new Duke(new GuiUserInputHandler(userChatInputField, dialogContainer,
                 images[0]),
                 new GuiUserOutputHandler(dialogContainer,

--- a/src/main/java/duke/gui/DialogBox.java
+++ b/src/main/java/duke/gui/DialogBox.java
@@ -74,6 +74,7 @@ public class DialogBox extends HBox {
         this.setAlignment(Pos.CENTER_LEFT);
         ObservableList<Node> tmp = FXCollections.observableArrayList(this.getChildren());
         FXCollections.reverse(tmp);
+        assert this.getChildren().size() == tmp.size() : "Number of nodes should be the same after flipping";
         this.getChildren().setAll(tmp);
     }
 }

--- a/src/main/java/duke/messages/MessageConstants.java
+++ b/src/main/java/duke/messages/MessageConstants.java
@@ -36,7 +36,7 @@ public class MessageConstants {
                     + "Try \"yyyy-mm-dd\" instead.";
     public static final String MESSAGE_INVALID_TASK_NUMBER =
             "Oof!!! Task number provided is invalid. Please try another number.";
-    public static final String MESSAGE_INVALID_INTEGER = "Oof!!! Task number must be valid integer. eg. \"done 1\"";
+    public static final String MESSAGE_INVALID_INTEGER = "Oof!!! Task number must be valid integer. eg. 1";
     public static final String MESSAGE_TASK_FILE_IO_FAILURE = "Oof!!! Unable to read/write from save file.";
     public static final String MESSAGE_INVALID_TASK_DATA = "Oof!!! Saved task data is corrupted/invalid!"
             + "\nDuke failed to start. Please verify/delete the saved data file and restart Duke!";


### PR DESCRIPTION
The codebase does not include any assertions.

Adding assumptions allows us to improve code robustness by
detected potential programmer mistakes during runtime.

Add assertions at appropriate places, avoid asserting
public method arguments according to Sun best practices.

Assertions can be disabled and hence checking
public arguments with assertions can cause
errors to go undetected.