### PR TITLE
Add reminders feature

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -18,7 +18,7 @@ public class Duke {
     /**
      * Constructs an instance of the <code>Duke</code> chat bot with the provided input and output handlers.
      *
-     * @throws TaskFileIoException thrown when unable to read the save task file.
+     * @throws TaskFileIoException      thrown when unable to read the save task file.
      * @throws InvalidTaskDataException thrown when task file data is corrupted.
      */
     public Duke() throws TaskFileIoException, InvalidTaskDataException {
@@ -28,6 +28,7 @@ public class Duke {
 
     /**
      * Responds to provided user input.
+     *
      * @param userInput user input text to respond to.
      * @return chat bot response to user input.
      * @throws DukeException thrown when unable to handle user input.
@@ -38,6 +39,7 @@ public class Duke {
 
     /**
      * Returns a <code>String</code> which greets the user upon chat bot start up.
+     *
      * @return greeting message.
      */
     public String greetUser() {

--- a/src/main/java/duke/command/CommandType.java
+++ b/src/main/java/duke/command/CommandType.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
  * @author kevin9foong
  */
 public enum CommandType {
-    LIST, TODO, DEADLINE, EVENT, DELETE, DONE, FIND, BYE;
+    LIST, TODO, DEADLINE, EVENT, DELETE, DONE, FIND, REMINDER, BYE;
 
     /**
      * Returns Command classification based on the given string.
@@ -20,7 +20,7 @@ public enum CommandType {
         return Arrays.stream(CommandType.values())
                 .reduce(null, (selectedCmd, currentCmd) ->
                         selectedCmd == null && commandText.toUpperCase().equals(currentCmd.toString())
-                        ? currentCmd
-                        : selectedCmd);
+                                ? currentCmd
+                                : selectedCmd);
     }
 }

--- a/src/main/java/duke/command/ReminderCommand.java
+++ b/src/main/java/duke/command/ReminderCommand.java
@@ -1,0 +1,71 @@
+package duke.command;
+
+import static java.util.stream.Collectors.toList;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+import duke.messages.DeadlineReminderMessage;
+import duke.tasks.Deadline;
+import duke.tasks.TaskList;
+
+/**
+ * Handles reminding the user of upcoming deadlines for the specified time period.
+ * <p>
+ * There are 3 time periods to filter deadlines by, all which is by default, due in a week and
+ * due by today.
+ *
+ * @author kevin9foong
+ */
+public class ReminderCommand extends Command {
+
+    /**
+     * Constructs an instance of <code>ReminderCommand</code> which when executes lists deadlines that are
+     * due according to user's specified time frame.
+     *
+     * @param userInputBody specifies desired time frame to limit due dates to. Include "week" or "today" to specify
+     *                      a specific time frame.
+     */
+    public ReminderCommand(String userInputBody) {
+        super(userInputBody);
+    }
+
+    /**
+     * Filters tasks for incomplete deadlines which due dates are within user's specified time frame and
+     * returns chat bot response to be displayed to user which lists the filtered upcoming deadlines.
+     *
+     * @param taskList handles task operations including adding, deleting, marking as done and retrieval.
+     * @return response message which lists upcoming incomplete deadlines within user's specified time frame.
+     */
+    @Override
+    public String execute(TaskList taskList) {
+        String userInput = super.getUserInputBody();
+
+        String timeScope = "ALL";
+        List<Deadline> deadlines = taskList.getAllTasks().stream().filter(t -> !t.getIsDone() && t instanceof Deadline)
+                .map(Deadline.class::cast).sorted((Comparator.comparing(Deadline::getDueDate))).collect(toList());
+
+        if (userInput != null && userInput.contains("week")) {
+            deadlines = deadlines.stream().filter(d -> d.getDueDate()
+                    .compareTo(LocalDate.now().plusWeeks(1)) < 0).collect(toList());
+            timeScope = "WEEK";
+        } else if (userInput != null && userInput.contains("today")) {
+            deadlines = deadlines.stream().filter(d -> d.getDueDate()
+                    .compareTo(LocalDate.now().plusDays(1)) < 0).collect(toList());
+            timeScope = "TODAY";
+        }
+
+        return new DeadlineReminderMessage(deadlines, timeScope).toString();
+    }
+
+    /**
+     * Returns false to indicate program should not terminate after command is executed.
+     *
+     * @return false to indicate program should not terminate after command is executed.
+     */
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/duke/fulfillment/Parser.java
+++ b/src/main/java/duke/fulfillment/Parser.java
@@ -10,6 +10,7 @@ import duke.command.DeleteTaskCommand;
 import duke.command.FindTasksCommand;
 import duke.command.ListTasksCommand;
 import duke.command.MarkTaskDoneCommand;
+import duke.command.ReminderCommand;
 import duke.exceptions.DukeException;
 import duke.exceptions.InvalidCommandException;
 
@@ -42,6 +43,8 @@ public class Parser {
             switch (userCommandType) {
             case LIST:
                 return new ListTasksCommand(userInputBody);
+            case REMINDER:
+                return new ReminderCommand(userInputBody);
             case TODO:
                 return new AddTodoCommand(userInputBody);
             case DEADLINE:

--- a/src/main/java/duke/messages/DeadlineReminderMessage.java
+++ b/src/main/java/duke/messages/DeadlineReminderMessage.java
@@ -1,0 +1,40 @@
+package duke.messages;
+
+import java.util.List;
+
+import duke.tasks.Task;
+
+/**
+ * Class is responsible for generating the message for the reminder command.
+ *
+ * @author kevin9foong
+ */
+public class DeadlineReminderMessage extends Message {
+    /**
+     * Constructs an instance of <code>DeadlineReminderMessage</code> which generates a message
+     * which displays the list of deadlines in order of list provided.
+     *
+     * @param tasks deadlines to include in output message.
+     */
+    public DeadlineReminderMessage(List<? extends Task> tasks, String timeScope) {
+        super.setMessageText(MessageConstants.MESSAGE_DEADLINE_REMINDER_HEADER + " (" + timeScope + "): "
+                + generateDeadlineReminderText(tasks));
+    }
+
+    /**
+     * Generates message from given list.
+     *
+     * @param tasks deadlines to be included in the message.
+     * @return user-friendly message including textual representations of all tasks
+     * provided in the given list.
+     */
+    private String generateDeadlineReminderText(List<? extends Task> tasks) {
+        StringBuilder listMessageBuilder = new StringBuilder();
+        for (Task task : tasks) {
+            listMessageBuilder
+                    .append("\n")
+                    .append(task.toString());
+        }
+        return listMessageBuilder.toString();
+    }
+}

--- a/src/main/java/duke/messages/MessageConstants.java
+++ b/src/main/java/duke/messages/MessageConstants.java
@@ -11,6 +11,8 @@ public class MessageConstants {
     public static final String MESSAGE_TASK_ADD_HEADER = "Got it. I've added this task:\n\t";
     public static final String MESSAGE_TASK_DONE_HEADER = "Nice! I've marked this task as done:";
     public static final String MESSAGE_TASK_LIST_HEADER = "Here are the tasks in your list:";
+    public static final String MESSAGE_DEADLINE_REMINDER_HEADER = "Here's the list of "
+            + "incomplete tasks sorted by deadline";
     public static final String MESSAGE_FIND_TASK_LIST = "Here are the tasks with matching descriptions in your list:";
     public static final String MESSAGE_TASK_DELETE_HEADER = "Noted. I've removed this task:\n\t";
     public static final String MESSAGE_INVALID_COMMAND =

--- a/src/main/java/duke/messages/TaskListMessage.java
+++ b/src/main/java/duke/messages/TaskListMessage.java
@@ -18,7 +18,7 @@ public class TaskListMessage extends Message {
      *
      * @param tasks tasks to include in output message.
      */
-    public TaskListMessage(List<Task> tasks) {
+    public TaskListMessage(List<? extends Task> tasks) {
         super.setMessageText(MessageConstants.MESSAGE_TASK_LIST_HEADER
                 + generateListMessageText(tasks));
     }
@@ -30,7 +30,7 @@ public class TaskListMessage extends Message {
      * @return user-friendly message including textual representations of all tasks
      * provided in the given list.
      */
-    private String generateListMessageText(List<Task> tasks) {
+    private String generateListMessageText(List<? extends Task> tasks) {
         StringBuilder listMessageBuilder = new StringBuilder();
         for (int index = 0; index < tasks.size(); index++) {
             listMessageBuilder

--- a/src/main/java/duke/tasks/Deadline.java
+++ b/src/main/java/duke/tasks/Deadline.java
@@ -13,7 +13,7 @@ import duke.exceptions.InvalidDeadlineBodyException;
  * @author kevin9foong
  */
 public class Deadline extends Task {
-    private final LocalDate by;
+    private final LocalDate dueDate;
 
     /**
      * Instantiates a <code>Deadline</code> from its data String representation.
@@ -37,7 +37,7 @@ public class Deadline extends Task {
         }
         super.setDescription(deadlineData[0].trim());
         try {
-            this.by = LocalDate.parse(deadlineData[1].trim());
+            this.dueDate = LocalDate.parse(deadlineData[1].trim());
         } catch (DateTimeParseException dte) {
             throw new InvalidDateTimeFormatException();
         }
@@ -49,17 +49,21 @@ public class Deadline extends Task {
      *
      * @param description description of what the <code>Deadline</code> entails.
      * @param isDone      completion status of <code>Deadline</code>.
-     * @param by          deadline which <code>Deadline</code> must be completed.
+     * @param dueDate     deadline which <code>Deadline</code> must be completed.
      */
-    public Deadline(String description, boolean isDone, LocalDate by) {
+    public Deadline(String description, boolean isDone, LocalDate dueDate) {
         super.setDescription(description);
         super.setIsDone(isDone);
-        this.by = by;
+        this.dueDate = dueDate;
+    }
+
+    public LocalDate getDueDate() {
+        return this.dueDate;
     }
 
     @Override
     public String getTaskRepresentation() {
-        return TaskType.DEADLINE + " |;; " + super.getTaskRepresentation() + this.by + " |;; ";
+        return TaskType.DEADLINE + " |;; " + super.getTaskRepresentation() + this.dueDate + " |;; ";
     }
 
     /**
@@ -71,6 +75,6 @@ public class Deadline extends Task {
     @Override
     public String toString() {
         return "[D]" + super.toString()
-                + " (by: " + by.getMonth() + " " + by.getDayOfMonth() + " " + by.getYear() + ")";
+                + " (by: " + dueDate.getMonth() + " " + dueDate.getDayOfMonth() + " " + dueDate.getYear() + ")";
     }
 }

--- a/src/main/java/duke/tasks/Task.java
+++ b/src/main/java/duke/tasks/Task.java
@@ -63,6 +63,10 @@ public abstract class Task {
         return (isDone ? "X" : " "); // mark done task with X
     }
 
+    public boolean getIsDone() {
+        return this.isDone;
+    }
+
     /**
      * Converts this task's data to representation to be saved in file.
      *

--- a/src/main/resources/view/DialogBox.fxml
+++ b/src/main/resources/view/DialogBox.fxml
@@ -4,16 +4,18 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
-
-<fx:root alignment="CENTER_RIGHT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="400.0" spacing="20.0" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root alignment="CENTER_RIGHT" maxHeight="-Infinity" minHeight="-Infinity" spacing="20.0"
+         type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <Label fx:id="dialogLabel" graphicTextGap="6.0" text="Label" wrapText="true" />
-        <ImageView fx:id="avatarImageView" fitHeight="80.0" fitWidth="80.0" pickOnBounds="true" preserveRatio="true" HBox.hgrow="ALWAYS" />
+        <Label fx:id="dialogLabel" graphicTextGap="6.0" maxHeight="-Infinity" minHeight="-Infinity" text="Label"
+               textOverrun="WORD_ELLIPSIS" wrapText="true"/>
+        <ImageView fx:id="avatarImageView" fitHeight="80.0" fitWidth="80.0" pickOnBounds="true" preserveRatio="true"
+                   HBox.hgrow="ALWAYS"/>
     </children>
     <padding>
-        <Insets bottom="15.0" left="10.0" right="10.0" top="15.0" />
+        <Insets bottom="15.0" left="10.0" right="10.0" top="15.0"/>
     </padding>
-   <opaqueInsets>
-      <Insets />
-   </opaqueInsets>
+    <opaqueInsets>
+        <Insets/>
+    </opaqueInsets>
 </fx:root>

--- a/src/test/java/duke/command/ReminderCommandTest.java
+++ b/src/test/java/duke/command/ReminderCommandTest.java
@@ -1,0 +1,80 @@
+package duke.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import duke.data.TaskStorageStub;
+import duke.exceptions.InvalidTaskDataException;
+import duke.exceptions.TaskFileIoException;
+import duke.tasks.Deadline;
+import duke.tasks.TaskList;
+
+public class ReminderCommandTest {
+    @Test
+    void deadlineWeekFilterAndSortingWorks_userInputReminderForWeekCommand_messageIncludesWeekDeadlines()
+            throws TaskFileIoException, InvalidTaskDataException {
+        Deadline expectedDeadlineA = new Deadline("a", false, LocalDate.now().plusDays(6));
+        Deadline expectedDeadlineB = new Deadline("b", false, LocalDate.now().plusDays(3));
+        Deadline expectedDeadlineC = new Deadline("c", false, LocalDate.now().plusDays(0));
+        Deadline excludedDeadlineD = new Deadline("d", true, LocalDate.now().plusDays(0));
+        Deadline excludedDeadlineE = new Deadline("e", false, LocalDate.now().plusDays(20));
+
+        TaskList taskList = new TaskList(new TaskStorageStub());
+        taskList.addTask(expectedDeadlineA);
+        taskList.addTask(expectedDeadlineB);
+        taskList.addTask(expectedDeadlineC);
+        taskList.addTask(excludedDeadlineD);
+        taskList.addTask(excludedDeadlineE);
+        String agentResponse = new ReminderCommand("week").execute(taskList);
+
+        assertEquals("Here's the list of incomplete tasks sorted by deadline (WEEK): \n"
+                + expectedDeadlineC.toString() + "\n"
+                + expectedDeadlineB.toString() + "\n"
+                + expectedDeadlineA.toString(), agentResponse);
+    }
+
+    @Test
+    void deadlineAllFilterAndSortingWorks_userInputReminderAllCommand_messageIncludesAllDeadlines()
+            throws TaskFileIoException, InvalidTaskDataException {
+        Deadline expectedDeadlineA = new Deadline("a", false, LocalDate.now().plusDays(20));
+        Deadline expectedDeadlineB = new Deadline("b", false, LocalDate.now().plusDays(3));
+        Deadline expectedDeadlineC = new Deadline("c", false, LocalDate.now().plusDays(1));
+        Deadline expectedDeadlineD = new Deadline("d", true, LocalDate.now().plusDays(0));
+
+        TaskList taskList = new TaskList(new TaskStorageStub());
+        taskList.addTask(expectedDeadlineA);
+        taskList.addTask(expectedDeadlineB);
+        taskList.addTask(expectedDeadlineC);
+        taskList.addTask(expectedDeadlineD);
+        String agentResponse = new ReminderCommand("gibberish text").execute(taskList);
+
+        assertEquals("Here's the list of incomplete tasks sorted by deadline (ALL): \n"
+                + expectedDeadlineC.toString() + "\n"
+                + expectedDeadlineB.toString() + "\n"
+                + expectedDeadlineA.toString(), agentResponse);
+    }
+
+    @Test
+    void deadlineTodayFilterAndSortingWorks_userInputReminderTodayCommand_messageIncludesTodayDeadlines()
+            throws TaskFileIoException, InvalidTaskDataException {
+        Deadline expectedDeadlineA = new Deadline("a", false, LocalDate.now().plusDays(20));
+        Deadline expectedDeadlineB = new Deadline("b", false, LocalDate.now().plusDays(3));
+        Deadline expectedDeadlineC = new Deadline("c", false, LocalDate.now().plusDays(1));
+        Deadline expectedDeadlineD = new Deadline("d", false, LocalDate.now().plusDays(0));
+        Deadline expectedDeadlineE = new Deadline("e", true, LocalDate.now().plusDays(0));
+
+        TaskList taskList = new TaskList(new TaskStorageStub());
+        taskList.addTask(expectedDeadlineA);
+        taskList.addTask(expectedDeadlineB);
+        taskList.addTask(expectedDeadlineC);
+        taskList.addTask(expectedDeadlineD);
+        taskList.addTask(expectedDeadlineE);
+        String agentResponse = new ReminderCommand("today").execute(taskList);
+
+        assertEquals("Here's the list of incomplete tasks sorted by deadline (TODAY): \n"
+                + expectedDeadlineD.toString(), agentResponse);
+    }
+}


### PR DESCRIPTION
Add extension B-Reminders which provides users to check a sorted list of upcoming deadlines in chronological order of due dates. 

Users can filter the upcoming deadlines by today, week or by all. 

The command for usage is 'reminder week' for week filter, 'reminder today' for today filter or simply 'reminder' to get all incomplete deadlines sorted in chronological order. 